### PR TITLE
FIX: xsmall media query didn't have a valid open tag

### DIFF
--- a/build/global/css/helpers/queries.css
+++ b/build/global/css/helpers/queries.css
@@ -1,1 +1,0 @@
-@media only screen and (min-width: 56em) {

--- a/build/global/css/helpers/queries.xsmall.css
+++ b/build/global/css/helpers/queries.xsmall.css
@@ -1,0 +1,1 @@
+@media only screen {


### PR DESCRIPTION
I added in the `queries.xsmall.css` file with a basic open tag, so that it is picked up by the updated gruntfile. removed unused `queries.css` file.
